### PR TITLE
Scan imap for vulnerabilities

### DIFF
--- a/cmd/imapscan/main.go
+++ b/cmd/imapscan/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"imapscan/imap"
+)
+
+func main() {
+	target := flag.String("target", "127.0.0.1", "Target host or IP")
+	timeout := flag.Int("timeout", 5, "Timeout in seconds")
+	flag.Parse()
+
+	results := imap.RunIMAP(*target, *timeout)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		fmt.Fprintf(os.Stderr, "encode error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module imapscan
+
+go 1.21.0

--- a/imap/imap.go
+++ b/imap/imap.go
@@ -66,22 +66,23 @@ func scanIMAPPlain(target string, port int, timeout time.Duration) (banner strin
 	reader := textproto.NewReader(bufio.NewReader(conn))
 	writer := textproto.NewWriter(bufio.NewWriter(conn))
 
-	// server greeting (untagged)
-	greet, _ := reader.ReadLine()
-	banner = strings.TrimSpace(greet)
+	// Read greeting and any inline [CAPABILITY ...]
+	greetBanner, greetCaps := readGreeting(reader)
+	banner = greetBanner
 
-	capabilities, starttlsSupported, logindisabled := fetchCapabilities(reader, writer, timeout)
-	starttls = starttlsSupported
+	// Expand capabilities with CAPABILITY command
+	caps2, starttlsSupported, logindisabled := fetchCapabilities(reader, writer, timeout)
+	caps := mergeCaps(greetCaps, caps2)
+	_ = caps
+	starttls = starttlsSupported || hasToken(caps, "STARTTLS")
 
 	// Determine if plaintext login is allowed on the current (unencrypted) connection
-	// If LOGINDISABLED is present, plaintext login should be disabled until STARTTLS
-	if logindisabled {
+	if logindisabled || hasToken(caps, "LOGINDISABLED") {
 		plaintextAllowed = false
 		return
 	}
 
-	// If capabilities advertise LOGIN or AUTH=PLAIN, attempt a safe LOGIN to test policy
-	if hasLoginCapability(capabilities) {
+	if hasLoginCapability(caps) {
 		tag := "B001"
 		_ = writer.PrintfLine("%s LOGIN test test", tag)
 		_ = writer.W.Flush()
@@ -99,11 +100,9 @@ func scanIMAPPlain(target string, port int, timeout time.Duration) (banner strin
 		plaintextResp = strings.TrimSpace(strings.Join(respLines, "\n"))
 
 		upperResp := strings.ToUpper(plaintextResp)
-		// If server responds BAD and mentions TLS/ENCRYPTION required, then plaintext is not allowed
 		if strings.Contains(upperResp, "TLS") || strings.Contains(upperResp, "ENCRYPT") || strings.Contains(upperResp, "STARTTLS") || strings.Contains(upperResp, "LOGINDISABLED") {
 			plaintextAllowed = false
 		} else {
-			// NO or OK both indicate that LOGIN command can be processed on plaintext channel
 			plaintextAllowed = true
 		}
 	} else {
@@ -126,17 +125,61 @@ func scanIMAPTLS(target string, port int, timeout time.Duration) (banner string,
 	reader := textproto.NewReader(bufio.NewReader(conn))
 	writer := textproto.NewWriter(bufio.NewWriter(conn))
 
-	greet, _ := reader.ReadLine()
-	banner = strings.TrimSpace(greet)
+	greetBanner, greetCaps := readGreeting(reader)
+	banner = greetBanner
 
-	capabilities, _, _ := fetchCapabilities(reader, writer, timeout)
-	_ = capabilities
+	caps2, starttlsSupported, _ := fetchCapabilities(reader, writer, timeout)
+	caps := mergeCaps(greetCaps, caps2)
+	starttls = starttlsSupported || hasToken(caps, "STARTTLS")
 
-	// On implicit TLS, plaintext over the wire is already encrypted, so we do not flag it as plaintext vulnerability
+	// On implicit TLS, plaintext over the wire is already encrypted
 	plaintextAllowed = false
-	starttls = false
 	plaintextResp = ""
 	return
+}
+
+func readGreeting(reader *textproto.Reader) (banner string, caps []string) {
+	var first string
+	var found bool
+	var foundCaps []string
+	for i := 0; i < 20; i++ {
+		line, err := reader.ReadLine()
+		if err != nil {
+			break
+		}
+		if !found {
+			first = strings.TrimSpace(line)
+			found = true
+		}
+		upper := strings.ToUpper(line)
+		// Typical greeting starts with "* OK" or "* PREAUTH"
+		if strings.HasPrefix(upper, "* OK") || strings.HasPrefix(upper, "* PREAUTH") || strings.HasPrefix(upper, "* BYE") {
+			lcap := parseBracketCapabilities(line)
+			if len(lcap) > 0 {
+				foundCaps = append(foundCaps, lcap...)
+			}
+			// Some servers only send one line; we don't strictly require a terminator here
+			// Break after capturing first significant greeting line
+			break
+		}
+	}
+	return first, normalizeCaps(foundCaps)
+}
+
+func parseBracketCapabilities(line string) []string {
+	upper := strings.ToUpper(line)
+	start := strings.Index(upper, "[CAPABILITY ")
+	if start < 0 {
+		return nil
+	}
+	start += len("[CAPABILITY ")
+	end := strings.Index(upper[start:], "]")
+	if end < 0 {
+		return nil
+	}
+	segment := line[start : start+end]
+	tokens := strings.Fields(segment)
+	return normalizeCaps(tokens)
 }
 
 func fetchCapabilities(reader *textproto.Reader, writer *textproto.Writer, timeout time.Duration) (capabilities []string, hasStartTLS bool, hasLoginDisabled bool) {
@@ -152,9 +195,9 @@ func fetchCapabilities(reader *textproto.Reader, writer *textproto.Writer, timeo
 		upper := strings.ToUpper(line)
 		if strings.HasPrefix(line, "*") && strings.Contains(upper, "CAPABILITY") {
 			// Example: * CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN
-			// collect tokens after CAPABILITY keyword
 			idx := strings.Index(upper, "CAPABILITY")
 			if idx >= 0 {
+				// slice original line maintains token cases
 				fields := strings.Fields(line[idx+len("CAPABILITY"):])
 				for _, f := range fields {
 					caps = append(caps, strings.TrimSpace(f))
@@ -167,10 +210,7 @@ func fetchCapabilities(reader *textproto.Reader, writer *textproto.Writer, timeo
 		}
 	}
 
-	upperCaps := make([]string, 0, len(caps))
-	for _, c := range caps {
-		upperCaps = append(upperCaps, strings.ToUpper(c))
-	}
+	upperCaps := normalizeCaps(caps)
 	capabilities = upperCaps
 	for _, c := range upperCaps {
 		if c == "STARTTLS" {
@@ -198,9 +238,52 @@ func hasInfoLeak(banner string) bool {
 		return false
 	}
 	// Common IMAP server products that often leak in greeting/banners
-	leakers := []string{"dovecot", "cyrus", "courier", "uw-imap", "imap"}
+	leakers := []string{"dovecot", "cyrus", "courier", "uw-imap", "exchange", "gmail", "cisco", "citadel", "hmailserver", "imap"}
 	for _, k := range leakers {
 		if strings.Contains(b, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeCaps(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, t := range in {
+		u := strings.ToUpper(strings.TrimSpace(t))
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	return out
+}
+
+func mergeCaps(a, b []string) []string {
+	if len(a) == 0 {
+		return normalizeCaps(b)
+	}
+	if len(b) == 0 {
+		return normalizeCaps(a)
+	}
+	return normalizeCaps(append(append([]string{}, a...), b...))
+}
+
+func hasToken(caps []string, token string) bool {
+	if len(caps) == 0 {
+		return false
+	}
+	t := strings.ToUpper(token)
+	for _, c := range caps {
+		if c == t {
 			return true
 		}
 	}

--- a/imap/imap.go
+++ b/imap/imap.go
@@ -1,0 +1,208 @@
+package imap
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/textproto"
+	"strings"
+	"time"
+)
+
+// IMAPResult holds scan results for an IMAP endpoint
+type IMAPResult struct {
+	Target            string
+	Port              int
+	Banner            string
+	InfoLeak          bool
+	STARTTLS          bool
+	PlaintextAuth     bool
+	PlaintextAuthResp string
+}
+
+// RunIMAP runs IMAP scan for standard ports 143 (plain with optional STARTTLS) and 993 (implicit TLS)
+func RunIMAP(target string, timeoutSec int) []*IMAPResult {
+	timeout := time.Duration(timeoutSec) * time.Second
+	imapPorts := []int{143, 993}
+	var results []*IMAPResult
+
+	for _, port := range imapPorts {
+		res := &IMAPResult{Target: target, Port: port}
+		banner, starttls, plaintext, plaintextResp, err := scanPort(target, port, timeout)
+		if err != nil {
+			// Append result even if closed/unreachable to preserve output shape
+			results = append(results, res)
+			continue
+		}
+
+		res.Banner = banner
+		res.InfoLeak = hasInfoLeak(banner)
+		res.STARTTLS = starttls
+		res.PlaintextAuth = plaintext
+		res.PlaintextAuthResp = plaintextResp
+		results = append(results, res)
+	}
+
+	return results
+}
+
+func scanPort(target string, port int, timeout time.Duration) (banner string, starttls bool, plaintextAllowed bool, plaintextResp string, err error) {
+	if port == 993 {
+		return scanIMAPTLS(target, port, timeout)
+	}
+	return scanIMAPPlain(target, port, timeout)
+}
+
+func scanIMAPPlain(target string, port int, timeout time.Duration) (banner string, starttls bool, plaintextAllowed bool, plaintextResp string, err error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	conn, err := dialer.Dial("tcp", fmt.Sprintf("%s:%d", target, port))
+	if err != nil {
+		return "", false, false, "", err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	reader := textproto.NewReader(bufio.NewReader(conn))
+	writer := textproto.NewWriter(bufio.NewWriter(conn))
+
+	// server greeting (untagged)
+	greet, _ := reader.ReadLine()
+	banner = strings.TrimSpace(greet)
+
+	capabilities, starttlsSupported, logindisabled := fetchCapabilities(reader, writer, timeout)
+	starttls = starttlsSupported
+
+	// Determine if plaintext login is allowed on the current (unencrypted) connection
+	// If LOGINDISABLED is present, plaintext login should be disabled until STARTTLS
+	if logindisabled {
+		plaintextAllowed = false
+		return
+	}
+
+	// If capabilities advertise LOGIN or AUTH=PLAIN, attempt a safe LOGIN to test policy
+	if hasLoginCapability(capabilities) {
+		tag := "B001"
+		_ = writer.PrintfLine("%s LOGIN test test", tag)
+		_ = writer.W.Flush()
+		var respLines []string
+		for {
+			line, rerr := reader.ReadLine()
+			if rerr != nil {
+				break
+			}
+			respLines = append(respLines, line)
+			if strings.HasPrefix(line, tag+" OK") || strings.HasPrefix(line, tag+" NO") || strings.HasPrefix(line, tag+" BAD") {
+				break
+			}
+		}
+		plaintextResp = strings.TrimSpace(strings.Join(respLines, "\n"))
+
+		upperResp := strings.ToUpper(plaintextResp)
+		// If server responds BAD and mentions TLS/ENCRYPTION required, then plaintext is not allowed
+		if strings.Contains(upperResp, "TLS") || strings.Contains(upperResp, "ENCRYPT") || strings.Contains(upperResp, "STARTTLS") || strings.Contains(upperResp, "LOGINDISABLED") {
+			plaintextAllowed = false
+		} else {
+			// NO or OK both indicate that LOGIN command can be processed on plaintext channel
+			plaintextAllowed = true
+		}
+	} else {
+		plaintextAllowed = false
+	}
+
+	return
+}
+
+func scanIMAPTLS(target string, port int, timeout time.Duration) (banner string, starttls bool, plaintextAllowed bool, plaintextResp string, err error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	tlsConf := &tls.Config{InsecureSkipVerify: true, ServerName: target}
+	conn, err := tls.DialWithDialer(dialer, "tcp", fmt.Sprintf("%s:%d", target, port), tlsConf)
+	if err != nil {
+		return "", false, false, "", err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	reader := textproto.NewReader(bufio.NewReader(conn))
+	writer := textproto.NewWriter(bufio.NewWriter(conn))
+
+	greet, _ := reader.ReadLine()
+	banner = strings.TrimSpace(greet)
+
+	capabilities, _, _ := fetchCapabilities(reader, writer, timeout)
+	_ = capabilities
+
+	// On implicit TLS, plaintext over the wire is already encrypted, so we do not flag it as plaintext vulnerability
+	plaintextAllowed = false
+	starttls = false
+	plaintextResp = ""
+	return
+}
+
+func fetchCapabilities(reader *textproto.Reader, writer *textproto.Writer, timeout time.Duration) (capabilities []string, hasStartTLS bool, hasLoginDisabled bool) {
+	tag := "A001"
+	_ = writer.PrintfLine("%s CAPABILITY", tag)
+	_ = writer.W.Flush()
+	var caps []string
+	for i := 0; i < 200; i++ { // reasonable upper bound to avoid infinite loop
+		line, err := reader.ReadLine()
+		if err != nil {
+			break
+		}
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(line, "*") && strings.Contains(upper, "CAPABILITY") {
+			// Example: * CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN
+			// collect tokens after CAPABILITY keyword
+			idx := strings.Index(upper, "CAPABILITY")
+			if idx >= 0 {
+				fields := strings.Fields(line[idx+len("CAPABILITY"):])
+				for _, f := range fields {
+					caps = append(caps, strings.TrimSpace(f))
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(line, tag+" OK") || strings.HasPrefix(line, tag+" BAD") || strings.HasPrefix(line, tag+" NO") {
+			break
+		}
+	}
+
+	upperCaps := make([]string, 0, len(caps))
+	for _, c := range caps {
+		upperCaps = append(upperCaps, strings.ToUpper(c))
+	}
+	capabilities = upperCaps
+	for _, c := range upperCaps {
+		if c == "STARTTLS" {
+			hasStartTLS = true
+		}
+		if c == "LOGINDISABLED" {
+			hasLoginDisabled = true
+		}
+	}
+	return
+}
+
+func hasLoginCapability(capabilities []string) bool {
+	for _, c := range capabilities {
+		if c == "LOGIN" || strings.HasPrefix(c, "AUTH=") || strings.Contains(c, "LOGIN") || strings.Contains(c, "PLAIN") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasInfoLeak(banner string) bool {
+	b := strings.ToLower(banner)
+	if b == "" {
+		return false
+	}
+	// Common IMAP server products that often leak in greeting/banners
+	leakers := []string{"dovecot", "cyrus", "courier", "uw-imap", "imap"}
+	for _, k := range leakers {
+		if strings.Contains(b, k) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implement a robust IMAP scanner to accurately detect STARTTLS support and plaintext authentication vulnerabilities.

The previous IMAP scanning logic was unreliable, failing to correctly handle implicit TLS on port 993, properly parse server capabilities for STARTTLS, or accurately assess plaintext authentication risks on port 143. This rewrite addresses these issues by using `textproto` for robust communication, explicit TLS handling, and refined logic for vulnerability detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b17cc21-edc2-4e11-bf3b-c89e7254c9ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b17cc21-edc2-4e11-bf3b-c89e7254c9ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

